### PR TITLE
Update to BitGo SDK 1.0.0, bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lamassu-bitgo",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "Lamassu BitGo module",
   "main": "wallet.js",
   "repository": {
@@ -22,7 +22,7 @@
   },
   "devDependencies": {},
   "dependencies": {
-    "bitgo": "0.11.47",
+    "bitgo": "1.0.0",
     "lodash": "^2.4.1",
     "promptly": "~0.2.0",
     "lamassu-config": "~1.0.0"


### PR DESCRIPTION
The BitGo pricing changes coming on April 15 require the new SDK.