### PR TITLE
Require bitgo@2.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lamassu-bitgo",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Lamassu BitGo module",
   "main": "wallet.js",
   "repository": {
@@ -23,7 +23,7 @@
   "devDependencies": {},
   "dependencies": {
     "bignumber.js": "^2.3.0",
-    "bitgo": "^1.5.4",
+    "bitgo": "~2.2.4",
     "lamassu-config": "^0.4.4",
     "lodash": "^2.4.1",
     "promptly": "~0.2.0"


### PR DESCRIPTION
> [BitGo] raised the fee rate fallback maximum in our SDK because the existing value was now well below the going rate for transaction fees. This had been resulting in transactions which were very slow to confirm for certain customers.
> 
> Our SDK, at startup, and periodically, already fetches its settings from the server, and we had already updated these settings previously. However, in certain use cases of the SDK, particularly with BitGo Express, there can be a race condition causing the client default to be used, if a transaction is done prior to completion of the SDK's first fetch of the server-side values.
> 
> Thus, in order to prevent stuck transactions when sending, we recommend that all customers upgrade to the latest version (2.2.0) of BitGo Express, BitGoJS, or the BitGo CLI. Users of BitGoD should not be affected, but we still recommend you upgrade at your convenience.